### PR TITLE
feat(runner): add support for passing in an evergreen flag

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -166,7 +166,8 @@ if (argv.l) {
   return;
 }
 
-m(function(err) {
+let testOpts = argv.evergreen ? { evergreen: true } : {};
+m(testOpts, function(err) {
   if (err) return errorHandler(err);
   start();
 });

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -166,7 +166,7 @@ if (argv.l) {
   return;
 }
 
-let testOpts = argv.evergreen ? { evergreen: true } : {};
+const testOpts = argv.evergreen ? { evergreen: true } : {};
 m(testOpts, function(err) {
   if (err) return errorHandler(err);
   start();


### PR DESCRIPTION
This adds support for passing in an `evergreen` option onto `mongodb-version-manager` and then onto `mongodb-download-url` that will enable Linux distributions to be determined when running tests on Evergreen. 

Related to: 
- https://github.com/mongodb-js/download-url/pull/76
- https://github.com/mongodb-js/mongodb-core/commit/bb401e9b5209f28173f05d7ee5e60d32162fd421