### PR TITLE
mongodb-test-runner: Update mongodb-version-manager to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "metamocha": "^1.2.5",
     "mongodb-topology-manager": "^2.0.0",
-    "mongodb-version-manager": "^1.0.7",
+    "mongodb-version-manager": "^1.4.0",
     "semver": "^5.4.1",
     "yargs": "^8.0.2"
   },


### PR DESCRIPTION
The new release has been made in mongodb-version-manager with aarch64 support.  Updated the same in package.json.